### PR TITLE
Allow filtering redirect url when accesing extranet page unauthenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ function custom_floauth_modify_redirect_path( $redirect_path, $parameters ) {
 add_filter( 'floauth_modify_redirect_path', 'custom_floauth_modify_redirect_path', 10, 2 );
 ```
 
+### Modify redirect path for user with no access ###
+
+```
+function custom_floauth_restrict_extranet_block_redirect( $url ) {
+	// Do some magic
+	return $url;
+}
+add_filter( 'floauth_restrict_extranet_block_redirect', 'custom_floauth_restrict_extranet_block_redirect' );
+```
+
 ### Change capability for hiding extranet pages ###
 
 For example hide extranet pages from Subscriber also (default capability is `read`)

--- a/floauth.php
+++ b/floauth.php
@@ -448,7 +448,7 @@ function floauth_block_extranet_pages() {
 				$current_post_id = get_the_ID();
 				$ancestors = get_post_ancestors( $current_post_id );
 				if ( $restricted_post_id === $current_post_id || in_array( $restricted_post_id, $ancestors ) ) {
-					wp_redirect( home_url( '/' ) );
+					wp_redirect( apply_filters( 'floauth_restrict_extranet_block_redirect', home_url( '/' ) ) );
 					exit();
 				}
 			}


### PR DESCRIPTION
In some cases, it might be needed to redirect unauthenticated users from extranet pages to somewhere else than site front page. This PR adds a hook to allow that.